### PR TITLE
Allow personalize validate messages

### DIFF
--- a/MY_Model.php
+++ b/MY_Model.php
@@ -131,7 +131,7 @@ class MY_Model extends CI_Model
     /* validation */
     private $validated = TRUE;
     private $row_fields_to_update = array();
-
+    protected $validate_messages = array();
 
     /**
      * The various callbacks available to the model. Each are
@@ -279,6 +279,9 @@ class MY_Model extends CI_Model
             $rules = $this->rules['insert'];
         }
         $this->form_validation->set_rules($rules);
+        foreach ($this->validate_messages as $validate_message) {
+            $this->form_validation->set_message($validate_message['rule'], $validate_message['message']);
+        }
         if($this->form_validation->run())
         {
             $this->fillable_fields();


### PR DESCRIPTION
To set your own custom message for validate

Use in model extends MY_Model

```
protected $validate_messages = array(
        array(
            'rule'=> 'greater_than',
            'message' => '{field} is required'),
        array(
            'rule'=> 'required',
            'message' => '{field} is bla bla bla bla bla bla')
);
```

https://ellislab.com/codeigniter/user-guide/libraries/form_validation.html#settingerrors
