### PR TITLE
Fixed keeping default return_as

### DIFF
--- a/MY_Model.php
+++ b/MY_Model.php
@@ -941,7 +941,7 @@ class MY_Model extends CI_Model
             }
             if(!isset($pivot_table))
             {
-                $sub_results = $this->{$relation['foreign_model']}->as_array();
+                $sub_results = $this->{$relation['foreign_model']};
                 $select = array();
                 $select[] = '`'.$foreign_table.'`.`'.$foreign_key.'`';
                 if(!empty($request['parameters']))
@@ -994,10 +994,11 @@ class MY_Model extends CI_Model
                 $subs = array();
 
                 foreach ($sub_results as $result) {
-                    $the_foreign_key = $result[$foreign_key];
+                    $result_array = (array)$result;
+                    $the_foreign_key = $result_array[$foreign_key];
                     if(isset($pivot_table))
                     {
-                        $the_local_key = $result[singular($this->table) . '_' . $local_key];
+                        $the_local_key = $result_array[singular($this->table) . '_' . $local_key];
                         $subs[$the_local_key][$the_foreign_key] = $result;
                     }
                     else


### PR DESCRIPTION
> Trying to get property of non-object

Fixed keeping default `return_as` on multiple relationships on same page.

I try cast to array result item instead of changing to `return_as` with `as_array()` so i keep the model return type.
