### PR TITLE
Update the Update Method

### DIFF
--- a/MY_Model.php
+++ b/MY_Model.php
@@ -1,7 +1,7 @@
 <?php defined('BASEPATH') OR exit('No direct script access allowed');
 /*
 * Copyright (C) 2014 @avenirer [avenir.ro@gmail.com]
-* Everyone is permitted to copy and distribute verbatim or modified copies of this license document, 
+* Everyone is permitted to copy and distribute verbatim or modified copies of this license document,
 * and changing it is allowed as long as the name is changed.
 * DON'T BE A DICK PUBLIC LICENSE TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 *
@@ -11,12 +11,12 @@
 ********* 1b. Selling the unmodified original with no work done what-so-ever, that's REALLY being a dick.
 ********* 1c. Modifying the original work to contain hidden harmful content. That would make you a PROPER dick.
 ***** If you become rich through modifications, related works/services, or supporting the original work, share the love. Only a dick would make loads off this work and not buy the original works creator(s) a pint.
-***** Code is provided with no warranty. 
-*********** Using somebody else's code and bitching when it goes wrong makes you a DONKEY dick. 
+***** Code is provided with no warranty.
+*********** Using somebody else's code and bitching when it goes wrong makes you a DONKEY dick.
 *********** Fix the problem yourself. A non-dick would submit the fix back.
- * 
+ *
  */
- 
+
 /** how to extend MY_Model:
  *	class User_model extends MY_Model
  *	{
@@ -274,7 +274,7 @@ class MY_Model extends CI_Model
         {
             $data = json_decode(json_encode($data), FALSE);
         }
-        
+
         elseif($this->return_as == 'dropdown')
         {
             foreach($data as $row)
@@ -297,7 +297,7 @@ class MY_Model extends CI_Model
      * the row when doing an update
      * @return $this
      */
-    public function from_form($rules = NULL,$additional_values = NULL, $row_fields_to_update = array())
+    public function from_form($rules = NULL,$additional_values = array(), $row_fields_to_update = array())
     {
         $this->_get_table_fields();
         $this->load->library('form_validation');
@@ -317,7 +317,7 @@ class MY_Model extends CI_Model
                     $this->validated[$rule['field']] = $this->input->post($rule['field']);
                 }
             }
-            if(isset($additional_values) && is_array($additional_values) && !empty($additional_values))
+            if(!empty($additional_values))
             {
                 foreach($additional_values as $field => $value)
                 {
@@ -330,11 +330,16 @@ class MY_Model extends CI_Model
 
             if(!empty($row_fields_to_update))
             {
-                foreach ($row_fields_to_update as $field) {
+                foreach ($row_fields_to_update as $key => $field) {
                     if (in_array($field, $this->table_fields)) {
                         $this->row_fields_to_update[$field] = $this->input->post($field);
                     }
-
+                    else if (in_array($key, $this->table_fields)){
+                        $this->row_fields_to_update[$key] = $field;
+                    }
+                    else {
+                        continue;
+                    }
                 }
             }
             return $this;
@@ -452,7 +457,7 @@ class MY_Model extends CI_Model
                 $data[$this->_updated_at_field] = date('Y-m-d H:i:s');
             }
             $data = $this->trigger('before_update',$data);
-            if($this->validated!=FALSE && !empty($this->row_fields_to_update))
+            if($this->validated === FALSE && count($this->row_fields_to_update))
             {
                 $this->where($this->row_fields_to_update);
                 $this->row_fields_to_update = array();
@@ -1022,24 +1027,17 @@ class MY_Model extends CI_Model
                     if(isset($pivot_table))
                     {
                         $the_local_key = $result_array[singular($this->table) . '_' . $local_key];
-                        if(isset($relation['get_relate']) and $relation['get_relate'] === true)
-                        {
-                            $subs[$the_local_key][$the_foreign_key] = $this->{$relation['foreign_model']}->where($local_key, $result[$local_key])->get();
-                        }
-                        else
-                        {
-                            $subs[$the_local_key][$the_foreign_key] = $result;
-                        }
+                        $subs[$the_local_key][$the_foreign_key] = $result;
                     }
                     else
                     {
                         if($type=='has_one')
                         {
-                         $subs[$the_foreign_key] = $result;
+                            $subs[$the_foreign_key] = $result;
                         }
                         else
                         {
-                         $subs[$the_foreign_key][] = $result;
+                            $subs[$the_foreign_key][] = $result;
                         }
                     }
 
@@ -1063,7 +1061,7 @@ class MY_Model extends CI_Model
                     $order_by[$relation_key] = array(trim($elements[0]), trim($elements[1]));
                 }
                 else
-                {                
+                {
                     $order_by[$relation_key] = array(trim($elements[0]), 'desc');
                 }
             }
@@ -1072,7 +1070,7 @@ class MY_Model extends CI_Model
         if($order_by)
         {
             foreach($order_by as $field => $row)
-            {                
+            {
                 list($key, $value) = $row;
                 $data = $this->_build_sorter($data, $field, $key, $value);
             }
@@ -1132,7 +1130,7 @@ class MY_Model extends CI_Model
                         }
                         $this->_relationships[$key] = array('relation' => $option, 'relation_key' => $key, 'foreign_model' => $foreign_model_name, 'foreign_table' => $foreign_table, 'foreign_key' => $foreign_key, 'local_key' => $local_key);
                         ($option == 'has_many_pivot') ? ($this->_relationships[$key]['pivot_table'] = $pivot_table) : FALSE;
-                        ($option == 'has_many_pivot' && isset($relation[3])) ? ($this->_relationships[$key]['get_relate'] = TRUE) : FALSE;
+
                     }
                 }
             }
@@ -1542,12 +1540,12 @@ class MY_Model extends CI_Model
         }
         else echo 'No method with that name ('.$method.') in MY_Model.';
     }
-    
-    private function _build_sorter($data, $field, $order_by, $sort_by = 'DESC') 
+
+    private function _build_sorter($data, $field, $order_by, $sort_by = 'DESC')
     {
         usort($data, function($a, $b) use ($field, $order_by, $sort_by) {
             return strtoupper($sort_by) ==  "DESC" ? ($a[$field][$order_by] < $b[$field][$order_by]) : ($a[$field][$order_by] > $b[$field][$order_by]);
-        }); 
+        });
 
         return $data;
     }

--- a/MY_Model.php
+++ b/MY_Model.php
@@ -297,7 +297,7 @@ class MY_Model extends CI_Model
      * the row when doing an update
      * @return $this
      */
-    public function from_form($rules = NULL,$additional_values = array(), $row_fields_to_update = array())
+    public function from_form($rules = NULL,$additional_values = NULL, $row_fields_to_update = array())
     {
         $this->_get_table_fields();
         $this->load->library('form_validation');
@@ -317,7 +317,7 @@ class MY_Model extends CI_Model
                     $this->validated[$rule['field']] = $this->input->post($rule['field']);
                 }
             }
-            if(!empty($additional_values))
+            if(isset($additional_values) && is_array($additional_values) && !empty($additional_values))
             {
                 foreach($additional_values as $field => $value)
                 {
@@ -1027,7 +1027,14 @@ class MY_Model extends CI_Model
                     if(isset($pivot_table))
                     {
                         $the_local_key = $result_array[singular($this->table) . '_' . $local_key];
-                        $subs[$the_local_key][$the_foreign_key] = $result;
+                        if(isset($relation['get_relate']) and $relation['get_relate'] === true)
+                        {
+                            $subs[$the_local_key][$the_foreign_key] = $this->{$relation['foreign_model']}->where($local_key, $result[$local_key])->get();
+                        }
+                        else
+                        {
+                            $subs[$the_local_key][$the_foreign_key] = $result;
+                        }
                     }
                     else
                     {
@@ -1130,7 +1137,7 @@ class MY_Model extends CI_Model
                         }
                         $this->_relationships[$key] = array('relation' => $option, 'relation_key' => $key, 'foreign_model' => $foreign_model_name, 'foreign_table' => $foreign_table, 'foreign_key' => $foreign_key, 'local_key' => $local_key);
                         ($option == 'has_many_pivot') ? ($this->_relationships[$key]['pivot_table'] = $pivot_table) : FALSE;
-
+                        ($option == 'has_many_pivot' && isset($relation[3])) ? ($this->_relationships[$key]['get_relate'] = TRUE) : FALSE;
                     }
                 }
             }

--- a/README.md
+++ b/README.md
@@ -49,47 +49,47 @@ class User_model extends MY_Model
 {
 	public function __construct()
 	{
-		
+
 		// you can set the database connection that you want to use for this particular model, by passing the group connection name or a config array. By default will use the default connection
 		$this->_database_connection  = 'special_connection';
-		
+
 		// you can disable the use of timestamps. This way, MY_Model won't try to set a created_at and updated_at value on create methods. Also, if you pass it an array as calue, it tells MY_Model, that the first element is a created_at field type, the second element is a updated_at field type (and the third element is a deleted_at field type if $this->soft_deletes is set to TRUE)
 		$this->timestamps = TRUE
-		
+
 		// you can enable (TRUE) or disable (FALSE) the "soft delete" on records. Default is FALSE, which means that when you delete a row, that one is gone forever
         	$this->soft_deletes = FALSE
-              
+
         	// you can set how the model returns you the result: as 'array' or as 'object'. the default value is 'object'
 		$this->return_as = 'object' | 'array'
-		
+
 		// you can set relationships between tables
-		
+
 		//$this->has_one['...'] allows establishing ONE TO ONE or more ONE TO ONE relationship(s) between models/tables
 		$this->has_one['phone'] = 'Phone_model';
 		// or $this->has_one['phone'] = array('Phone_model','foreign_key','local_key');
 		$this->has_one['address'] = 'Address_model';
 		// or $this->has_one['address'] = array('Address_model','foreign_key','another_local_key');
-		
+
 		// $this->has_many[''...] allows establishing ONE TO MANY or more ONE TO MANY relationship(s) between models/tables
 		$this->has_many['posts'] = 'Post_model';
 		// or $this->has_many['posts'] = array('Posts_model','foreign_key','another_local_key');
-		
+
 		// $this->has_many_pivot['...'] allows establishing MANY TO MANY or more MANY TO MANY relationship(s) between models/tables with the use of a PIVOT TABLE
 		$this->has_many_pivot['posts'] = 'Post_model';
 		// or $this->has_many_pivot['posts'] = array('Posts_model','foreign_primary_key','local_primary_key');
-		
+
 		// ATTENTION! The pivot table name must be composed of the two table names separated by "_" the table names having to to be alphabetically ordered (NOT users_posts, but posts_users).
 		// Also the pivot table must contain as identifying columns the columns named by convention as follows: table_name_singular + _ + foreign_table_primary_key.
 		// For example: considering that a post can have multiple authors, a pivot table that connects two tables (users and posts) must be named posts_users and must have post_id and user_id as identifying columns for the posts.id and users.id tables.
-		
+
 		// you can also use caching. If you want to use the set_cache('...') method, but you want to change the way the caching is made you can use the following properties:
-		
+
 		$this->cache_driver = 'file';
 		//By default, MY_Model uses the files (CodeIgniter's file driver) to cache result. If you want to change the way it stores the cache, you can change the $cache_driver property to whatever CodeIgniter cache driver you want to use.
-		
+
 		$this->cache_prefix = 'mm';
 		With $cache_prefix, you can prefix the name of the caches. By default any cache made by MY_Model starts with 'mm' + _ + "name chosen for cache"
-  		
+
 		parent::__construct();
  	}
 }
@@ -311,11 +311,15 @@ $this->user_model->where('email','email@email.com')->update($update_data);
 
 The update can also be made directly from the form with validation, the same way as is done by the insert() method. The only difference would be that you need to specify which input field should be used as reference for the rows to be updated. You do this by passing a third parameter as array:
 ```php
-$this->user_model->from_form(NULL,NULL,array('user_id')); // where user_id is an input element
+$this->user_model->from_form(NULL,NULL,array('user_id'))->update(); // where user_id is an input element
+```
+Also, if you want to reference the field with a direct value that doesn't exist within the form, then you can assign it within the array too.
+```php
+$this->user_model->from_form(NULL,NULL,array('user_id' => 1))->update(); // where user_id is referenced directly
 ```
 If you need to use another table field that is not in the form, in order to identify the row, you can pass it to the from_form() method as a second parameter:
 ```php
-$id = $this->user_model->from_form(NULL,array('created_by'=>'1'), array('user_id))->update();
+$id = $this->user_model->from_form(NULL,array('created_by'=>'1'), array('user_id'))->update();
 ```
 
 ##DELETE


### PR DESCRIPTION
Current version doesn't let mass assignment on the reference field on update. To reference the field with a direct value that doesn't exist within the form, added the feature where you can assign it within the array too.

``` php
$this->user_model->from_form(NULL,NULL,array('user_id' => 1))->update(); // where user_id is not an input field, referenced directly
```

Thus, fixed a bug where validated is `FALSE` when data is chained within the `$this->validated`.
