### PR TITLE
"Undefined property" error fixed

### DIFF
--- a/MY_Model.php
+++ b/MY_Model.php
@@ -1060,6 +1060,10 @@ class MY_Model extends CI_Model
                     }
                 }
             }
+            else
+            {
+                $data[$key][$relation_key] = NULL;
+            }
             if(array_key_exists('order_by',$request['parameters']))
             {
                 $elements = explode(',', $request['parameters']['order_by']);


### PR DESCRIPTION
When i get relation data for example `with_category()` and if `category_id` empty, i got `Undefined property` error accessing `$post->category` because of not created `category` property. I try to fix with `NULL` value on empty relation.
