### PR TITLE
Reset query

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -439,6 +439,7 @@ class MY_Model extends CI_Model
         }
         elseif(!isset($data))
         {
+            $this->_database->reset_query();
             return FALSE;
         }
         // Prepare the data...


### PR DESCRIPTION
In my project I ran into an issue. After a failed update command it resulted into a SQL error in the session library 

UPDATE `sessions` SET `timestamp` = 1439836999 WHERE `tester`.`id` = 13 AND `id` = '....'

Where "`tester`.`id` = 13" is the part of the failed update command, since the update method failed it did not run the query and so the where clause stayed active in the query builder.

I fixed this by adding a reset_query() before the return false statement in the update method.
