### PR TITLE
fix you can't use : in the where in with_xyz

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -913,7 +913,7 @@ class MY_Model extends CI_Model
                     $requested_operations = explode('|',$argument);
                     foreach($requested_operations as $operation)
                     {
-                        $elements = explode(':', $operation);
+                        $elements = explode(':', $operation, 2);
                         if (sizeof($elements) == 2) {
                             $parameters[$elements[0]] = $elements[1];
                         } else {


### PR DESCRIPTION
Hi,
We couldn't use something like this code before this commit:

``` php
$this->user->with_post("where:`title`='12:00'")->get_all();
```
