### PR TITLE
Not getting data with have_pivot_many

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -1149,7 +1149,7 @@ class MY_Model extends CI_Model
                     $the_foreign_key = $result_array[$foreign_key];
                     if(isset($pivot_table))
                     {
-                        $the_local_key = $result_array[singular($this->table) . '_' . $local_key];
+                        $the_local_key = $result_array[ /* singular($this->table) . '_' . */ $local_key];
                         if(isset($get_relate) and $get_relate === TRUE)
                         {
                             $subs[$the_local_key][$the_foreign_key] = $this->{$relation['foreign_model']}->where($local_key, $result[$local_key])->get();

--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -1128,6 +1128,20 @@ class MY_Model extends CI_Model
                             $this->_database->select($the_select);
                         }
                     }
+			/*
+			to access column data on pivot_table itself with parameter 
+			like with_*('pivot_fields|column1,column2)'
+			*/
+                    if(array_key_exists('pivot_fields',$request['parameters']))
+                    {
+                        $fields = explode(',', $request['parameters']['pivot_fields']);
+                        $select = array();
+                        foreach ($fields as $field) {
+                            $select[] = '`' . $pivot_table . '`.`' . trim($field) . '`';
+                        }
+                        $the_select = implode(',', $select);
+                        $this->_database->select($the_select);
+                    }
 
                     if(array_key_exists('where',$request['parameters']) || array_key_exists('non_exclusive_where',$request['parameters']))
                     {


### PR DESCRIPTION
I define my have_pivot_many like the below. And I can only make it work when I comment out the singular($this->table) at like 1152

class Project_model extends MY_Model
{
    public function __construct()
    {
        $this->table = 'projects';
        $this->primary_key = 'project_id';

```
    $this->has_many_pivot['users'] = array(
                'foreign_model'=>'User_model',
                'pivot_table'=>'projects_users',
                'local_key'=>'project_id',
                'pivot_local_key'=>'project_id', 
                'pivot_foreign_key'=>'user_id',
                'foreign_key'=>'id',
                'get_relate'=>FALSE /* another optional setting, which is explained below */
            );
    parent::__construct();
}
```

}
