### PR TITLE
Getting single values 

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -932,13 +932,13 @@ class MY_Model extends CI_Model
     }
     
     /**
-     * public function get_as_field()
+     * public function fetch_field()
      * Retrieves one field of a row from table.
      * @param string $field
      * @param mixed $where
      * @return string
      */
-    public function get_as_field($field = NULL, $where = NULL)
+    public function fetch_field($field = NULL, $where = NULL)
     {
         if(is_null($field) || is_null($where))
         {

--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -930,7 +930,25 @@ class MY_Model extends CI_Model
             }
         }
     }
-
+    
+    /**
+     * public function get_as_field()
+     * Retrieves one field of a row from table.
+     * @param string $field
+     * @param mixed $where
+     * @return string
+     */
+    public function get_as_field($field = NULL, $where = NULL)
+    {
+        if(is_null($field) || is_null($where))
+        {
+            return FALSE;
+        }
+        $value = $this->fields($field)->get($where);
+        $value = is_object($value)?(array)$value:$value;
+        return $value[$field];
+    }
+    
     /**
      * public function count()
      * Retrieves number of rows from table.


### PR DESCRIPTION
basic fix for Issue #61
fetch_field('field_name','where clause')
Both parameters are required 
where clause same as get or get_all
usage 
$var = $this->some_model->fetch_field('field_name',$where_clause);
$var = $this->fetch_field('field_name', $where_clause);
