### PR TITLE
Change after_get observer to be per row in get_all

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -951,7 +951,8 @@ class MY_Model extends CI_Model
             if($query->num_rows() > 0)
             {
                 $data = $query->result_array();
-                $data = $this->trigger('after_get', $data);
+                foreach ($data as $key => $row)
+                    $data[$key] = $this->trigger('after_get', $row);
                 $data = $this->_prep_after_read($data,TRUE);
                 $this->_write_to_cache($data);
                 return $data;


### PR DESCRIPTION
The `after_get` behaviour is odd considering that it applies itself to both `get()` and `get_all()` queries. If the processing is made in an item-based manner, it'll fail when using `get_all()`. The opposite also happens, if `after_get` is set in a many-result manner, it'll fail for a single `get()`.

This change tries to standarize this behaviour.
