### PR TITLE
Fix a bug for nested relation and nice error

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -1220,7 +1220,7 @@ class MY_Model extends CI_Model
                     if(array_key_exists('with',$request['parameters']))
                     {
                         // Do we have many nested relation
-                        if(is_array($request['parameters']['with']) && isset($request['parameters']['with'][0]))
+                        if(is_array($request['parameters']['with']) && isset($request['parameters']['with'][0])&& is_array($request['parameters']['with'][0]))
                         {
                             foreach ($request['parameters']['with'] as $with)
                             {

--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -1984,8 +1984,8 @@ class MY_Model extends CI_Model
         $parent_class = get_parent_class($this);
         if ($parent_class !== FALSE && !method_exists($parent_class, $method) && !method_exists($this,$method))
         {
-            echo 'No method with that name ('.$method.') in '. get_class($this) .' or MY_Model or CI_Model.';
-            exit;
+            $msg = 'The method "'.$method.'" does not exist in '. get_class($this) .' or MY_Model or CI_Model.';
+            show_error($msg,EXIT_UNKNOWN_METHOD,'Method Not Found');
         }
     }
 


### PR DESCRIPTION
Nested relation bug: 
If a nested relation did not have a key for the relation it create an error with array_shift. 
@avenirer Can you check this one.

Nice Error: 
use CI show_error to warn about method not fund.