### PR TITLE
avoid a ambiguous column name error.

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -928,7 +928,7 @@ class MY_Model extends CI_Model
                     }
                     else
                     {
-                        $this->_database->select($this->_relationships[$requested['request']]['local_key']);
+                        $this->_database->select($this->table.'.'.$this->_relationships[$requested['request']]['local_key']);
                     }
                 }
             }
@@ -1002,7 +1002,7 @@ class MY_Model extends CI_Model
                     }
                     else
                     {
-                        $this->_database->select($this->_relationships[$requested['request']]['local_key']);
+                        $this->_database->select($this->table.'.'.$this->_relationships[$requested['request']]['local_key']);
                     }
                 }
             }


### PR DESCRIPTION
I make a table name explicit, because I intend to avoid "Query error: Column '{local_key}' in field list is ambiguous error" on MySQL.

The MySQL Error is "Error: 1052 SQLSTATE: 23000 (ER_NON_UNIQ_ERROR)" .