### PR TITLE
Duplicate WHERE clause with softdelete

### DIFF
--- a/core/MY_Model.php
+++ b/core/MY_Model.php
@@ -612,14 +612,6 @@ class MY_Model extends CI_Model
      */
     public function where($field_or_array = NULL, $operator_or_value = NULL, $value = NULL, $with_or = FALSE, $with_not = FALSE, $custom_string = FALSE)
     {
-        if($this->soft_deletes===TRUE)
-        {
-            $backtrace = debug_backtrace(); #fix for lower PHP 5.4 version
-            if($backtrace[1]['function']!='force_delete'){
-                $this->_where_trashed();
-            }
-        }
-
         if(is_array($field_or_array))
         {
             $multi = $this->is_multidimensional($field_or_array);
@@ -936,7 +928,7 @@ class MY_Model extends CI_Model
             {
                 $this->where($where);
             }
-            elseif($this->soft_deletes===TRUE)
+            if($this->soft_deletes===TRUE)
             {
                 $this->_where_trashed();
             }
@@ -984,7 +976,7 @@ class MY_Model extends CI_Model
             {
                 $this->where($where);
             }
-            elseif($this->soft_deletes===TRUE)
+            if($this->soft_deletes===TRUE)
             {
                 $this->_where_trashed();
             }
@@ -1035,7 +1027,7 @@ class MY_Model extends CI_Model
         {
             $this->where($where);
         }
-        elseif($this->soft_deletes===TRUE)
+        if($this->soft_deletes===TRUE)
         {
             $this->_where_trashed();
         }


### PR DESCRIPTION
Prevent duplicate WHERE clause when soft delete is use. 
When chaining the where method instead of passing the where as an argument to the read method, it creates a duplicate where clause for the deleted_at field.

This would fix issue #222 
I have tested it but it would be great if others try it before merging.