### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This **CodeIgniter MY_Model** is the result of a lengthy tutorial about construc
 
 **VERY IMPORTANT NOTE: MY_Model DOESN'T REPLACE THE QUERY BUILDER. IF YOU HAVE A VERY COMPLEX QUERY, DO NOT ASK MY_Model TO DO IT FOR YOU**
 
-##Synopsis
+## Synopsis
 ```php
 class User_model extends MY_Model { }
 
@@ -23,7 +23,7 @@ $this->user_model->update(array('status' => '0'), 1);
 $this->user_model->delete(1);
 ```
 
-##Installation/Usage
+## Installation/Usage
 
 Download and drag the **MY_Model.php** file into your **application/core** directory. CodeIgniter will load and initialise this class automatically.
 
@@ -97,9 +97,9 @@ class User_model extends MY_Model
 }
 ```
 
-##CREATE
+## CREATE
 
-###Inserting values
+### Inserting values
 
 You can insert values by using the **insert()** method, passing it an array or an object as parameter. You can also insert multiple rows of data by using a multidimensional array.
 
@@ -111,7 +111,7 @@ $this->user_model->insert($insert_data);
 ?>
 ```
 
-###Inserting directly from forms with form validation
+### Inserting directly from forms with form validation
 
 You can at any time directly insert values from forms into the tables using the **from_form()** method. First of all **make sure you have a fillable or a protected property (at least the primary key should be in there)**, because you must make sure no-one interferes with your id's or whatever you use to uniquely identify the rows. Also is worth noting that, because the inserts and updates from forms are done directly without intervention from developer, **YOU MUST DEFINE VALIDATION RULES FOR ALL FIELDS THAT YOU ARE FILLING**
 
@@ -220,9 +220,9 @@ $id = $this->user_model->from_form(NULL,array('created_by'=>'1'))->insert();
 ...
 ```
 
-##READ
+## READ
 
-###Arrays vs Objects
+### Arrays vs Objects
 
 By default, MY_Model is setup to return objects. If you'd like to return results as array you can:
 
@@ -233,7 +233,7 @@ $users = $this->user_model->as_array()->get_all(); $posts = $this->post_model->a
 ```
 If you'd like all your calls to use the array methods, you can set the $return_type variable to array.
 
-###Return as dropdown
+### Return as dropdown
 
 There are moments when you need to retrieve data to fill a select input type. For this we have a method called as_dropdown($field). This method will return an array having the primary keys as array keys and a $field as values:
 ```php
@@ -241,7 +241,7 @@ $categories = $this->category_model->as_dropdown('title')->get_all();
 echo form_dropdown($categories);
 ```
 
-###Caching
+### Caching
 
 If you want to cache the result for faster output, you can at any time use the MY_Model's caching. To do this you simply attach a set_cache('name') inside the query chain:
 
@@ -269,7 +269,7 @@ Example:
 $this->user_model->delete_cache('get_all_users');
 ```
 
-####Auto-delete caching
+#### Auto-delete caching
 
 You can set the model in a way so that the cache will be deleted automatically whenever you write/update/delete data from your model's table. This way you won't need to do it manually. You can have this enabled by setting the delete_cache_on_save property to TRUE in the constructor:
 
@@ -286,7 +286,7 @@ class User_model extends MY_Model
     ...
 ```
 
-##Pagination
+## Pagination
 
 You can at any time "paginate" the results. You can do this by simply changing `get_all()` method with `paginate()` method. The paginate() method can receive up to three parameters:
 
@@ -313,10 +313,10 @@ $this->pagination_arrows = array('&lt;','&gt;');
 ```
 Also, you can use the set_pagination_delimiters($delimiters) and set_pagination_arrows($arrows) methods, where $delimiters and $arrows are arrays.
 
-##UPDATE
-###The update() method
+## UPDATE
+### The update() method
 
-####The basic update()
+#### The basic update()
 
 The update() method is pretty much the same as the insert() method.
 
@@ -340,7 +340,7 @@ $this->user_model->update($update_data,'email');
 ```
 You can also pass a multidimensional array to change multiple rows. In this case the second parameter should be the name of the identifying column.
 
-####Update using the where() method
+#### Update using the where() method
 
 Another method to do an update would be to use the update() method in conjuction with the where() method:
 ```php
@@ -351,7 +351,7 @@ $this->user_model->where('email','email@email.com')->update($update_data);
 ?>
 ```
 
-####Update directly from form using from_form() method
+#### Update directly from form using from_form() method
 
 The update can also be made directly from the form with validation, the same way as is done by the insert() method. The only difference would be that you need to specify which input field should be used as reference for the rows to be updated. You do this by passing a third parameter as array:
 ```php
@@ -366,7 +366,7 @@ If you need to use another table field that is not in the form, in order to iden
 $id = $this->user_model->from_form(NULL,array('created_by'=>'1'), array('user_id'))->update();
 ```
 
-####Update custom string with disabled escaping
+#### Update custom string with disabled escaping
 
 You can prevent escaping content by passing an optional third argument, and setting it to FALSE (the second parameter is a where condition set as an array - you can set it to NULL):
 ```php
@@ -374,10 +374,10 @@ $this->user_model->update(array('views'=>'views+1'), array('id'=>'1'), FALSE);
 ```
 **TAKE CARE:** This doesn't work with values that have space inside unless you set quotes on them. So I would rather not use this (Maybe in future I will change the way this works)
 
-##DELETE
-###The delete() method
+## DELETE
+### The delete() method
 
-###Soft Deletes
+### Soft Deletes
 
 By default, the delete mechanism works with an SQL DELETE statement. However, you might not want to destroy the data, you might instead want to perform a **'soft delete'**.
 
@@ -411,19 +411,19 @@ You can also check if a row is **soft_deleted** by using `trashed()` method:
 $this->user_model->trashed(3); // will return TRUE or FALSE
 ```
 
-###The observers for the delete() method
+### The observers for the delete() method
 
 The before_soft_delete and before_delete observers offer the ID's of the rows that are about to be (soft) deleted. At the end of the callback you should return the array of ID's.
 
 The after_soft_delete and after_delete are also returning the ID's of the rows that you wanted deleted (Not those that have been deleted, so take care...). The one difference is that the array will also contain a key named "affected_rows" that will have the number of affected rows as value.
 
-##Relationships
+## Relationships
 
-###Creating relationships
+### Creating relationships
 
 When you extend MY_Model, you can also setup relationships between the model and other models. There are multiple ways of creating relations between tables:
 
-####The right way
+#### The right way
 
 Before `parent::__construct();` you add:
 
@@ -431,7 +431,7 @@ Before `parent::__construct();` you add:
 $this->has_one['phone'] = array('foreign_model'=>'Phone_model','foreign_table'=>'phones','foreign_key'=>'user_id','local_key'=>'id');
 ```
 
-####The semi-fast way
+#### The semi-fast way
 
 In the semi-fast way, you can simply pass the model, the foreign key and the local key (mind the order). The table name will be taken from the related model:
 
@@ -439,7 +439,7 @@ In the semi-fast way, you can simply pass the model, the foreign key and the loc
 $this->has_one['phone'] = array('Phone_model','foreign_key','local_key');
 ```
 
-####The fast and dirty way
+#### The fast and dirty way
 
 The fast and dirty way will simply need the related model name. All else will be taken from the model (I wouldn't advise this solution)
 
@@ -447,7 +447,7 @@ The fast and dirty way will simply need the related model name. All else will be
 $this->has_one['address'] = 'Address_model';
 ```
 
-###Has One (one to one) relationship (property)
+### Has One (one to one) relationship (property)
 
 Has One relationship tells our model that ever record in the table has assigned to it a record in another table. It is my opinion that there is no need to do a reverse relation like in Eloquent, where there is a "belongs to" relationship because, the truth be told, being a "one to one" relationship it's an equality between the entities.
 
@@ -504,11 +504,11 @@ class Post_model extends MY_Model
 }
 ```
 
-###Has Many Pivot relationship (property)
+### Has Many Pivot relationship (property)
 
 Many to many relationship can have one to one as reverse relationship. But there are also many to many relationships that have many to many as reverse relationships. For this we have has_many_pivot key as relation. This one allows establishing MANY TO MANY or more MANY TO MANY relationship(s) between models/tables with the use of a PIVOT TABLE.
 
-####Setting up a Has Many Pivot relationship THE RIGHT WAY
+#### Setting up a Has Many Pivot relationship THE RIGHT WAY
 
 For the MY_Model to work properly every single time, you must provide it every single detail:
 
@@ -534,7 +534,7 @@ class User_model extends MY_Model
  }
 ```
 
-####Setting up a Has Many Pivot relationship THE FAST AND PRONE TO ERRORS WAY.
+#### Setting up a Has Many Pivot relationship THE FAST AND PRONE TO ERRORS WAY.
 
 **ATTENTION**: The pivot table name must be composed of the two connected table names separated by _ (underscore) the table names having to be alphabetically ordered (NOT users_posts, but posts_users). Also the pivot table must contain as identifying columns the columns named by convention as follows: foreign_table_name_singular + _ (underscore) + foreign_table_primary_key.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
